### PR TITLE
Upgrade vst to ^0.2, output buffer is mutable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["doomy <alexanderpaullozada@gmail.com>"]
 
 [dependencies]
-vst = "0.0.2"
+vst = "^0.2"
 rand = "0.3"
 
 [lib]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@ impl Plugin for Whisper {
         // `buffer.split()` gives us a tuple containing the 
         // input and output buffers.  We only care about the
         // output, so we can ignore the input by using `_`.
-        let (_, output_buffer) = buffer.split();
+        let (_, mut output_buffer) = buffer.split();
 
         // We only want to process *anything* if a note is being held.
         // Else, we can fill the output buffer with silence.


### PR DESCRIPTION
When I tried to load the original (vst 0.0.1 or vst 0.0.2) into VSTHost or Ableton Live, they would crash.  Upgrading the vst crate to 0.2.x seems to fix this.  Also, output_buffer needed to be made mutable.